### PR TITLE
Convert project to static Netlify-ready web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,65 @@
 # 🐭 Mouse Escape: Q-Learning Agent
 
-This project demonstrates a **Q-learning agent** navigating a grid-based environment to reach its goal while avoiding obstacles like walls, "hell states," and teleportation tunnels. The agent learns to navigate efficiently using **reinforcement learning** with an epsilon-greedy policy.
+This project is now a **fully client-side simulation** that can be deployed as-is to
+[Netlify](https://www.netlify.com/) or any static hosting provider. A JavaScript
+implementation of the Q-learning agent trains entirely in the browser, so no
+backend services are required.
 
-## 🚀 Overview
+## 🚀 Features
 
-### Environment
-- **8x8 grid**: Agent starts at `(0, 0)` and aims to reach the goal at `(7, 7)`.
-- **Obstacles**: Walls (impassable), Hell States (negative rewards), and Teleportation Tunnels (instant movement).
+- **Interactive training controls** – configure episodes, learning rate, discount
+  factor, and epsilon schedule.
+- **Live environment visualization** – watch the 8×8 maze update as the agent
+  explores, including walls, hell states, and teleporters.
+- **Reward analytics** – a Chart.js line graph and summary stats track the
+  agent’s performance during training.
+- **Netlify-ready** – static assets (`index.html`, `style.css`, `script.js`) and a
+  minimal [`netlify.toml`](netlify.toml) publish configuration.
 
-### Rewards
-- **+10** for reaching the goal.
-- **-5** for entering Hell States.
-- **-0.01** for every move (living penalty).
+## 🧠 Environment Overview
 
-## ⚙️ Q-Learning
+- **Grid:** 8×8, with the mouse starting at `(0, 0)` and the goal at `(7, 7)`.
+- **Obstacles:**
+  - Walls (impassable)
+  - Hell states (−5 reward, terminal)
+  - Teleporters (instant relocation)
+- **Rewards:**
+  - `+10` for reaching the goal
+  - `−5` for entering a hell state
+  - `−0.01` living penalty per move
+- **Actions:** up, down, left, right
+- **Policy:** epsilon-greedy with configurable decay
 
-The agent uses Q-learning with the update formula:
-Q(s, a) = Q(s, a) + α [r + γ max_a' Q(s', a') - Q(s, a)]
-
-- **α (alpha)**: Learning rate.
-- **γ (gamma)**: Discount factor.
-- **Epsilon-Greedy Policy**: Balances exploration and exploitation, with decaying epsilon.
-
-### Actions
-- **Move Up**: Decreases y-coordinate.
-- **Move Down**: Increases y-coordinate.
-- **Move Left**: Decreases x-coordinate.
-- **Move Right**: Increases x-coordinate.
-
-## 🛠️ How to Run
-
-
+## 🛠️ Local Development
 
 1. Clone the repository:
    ```bash
    git clone https://github.com/yourusername/mouse-escape-qlearning.git
-
-2. Install dependencies:
+   cd mouse-escape-qlearning
+   ```
+2. Start a local static server (any option works). For example, using Python:
    ```bash
-   pip install -r requirements.txt
+   python -m http.server 8000
+   ```
+3. Visit the site:
+   ```bash
+   http://localhost:8000/
+   ```
 
-3. Run the simulation:
-    ```bash
-    python main.py
+Alternatively, open `index.html` directly in your browser.
 
-  📈 Future Work
-Multi-agent learning with cooperative or competitive strategies.
-Implementing deep Q-learning to improve decision-making.
+## 🌐 Deploying to Netlify
+
+1. [Create a new site from Git](https://app.netlify.com/start) and select this
+   repository.
+2. Use the defaults:
+   - **Build command:** leave empty (the project is prebuilt)
+   - **Publish directory:** `.`
+3. Deploy. Netlify will serve the static files immediately, and the Q-learning
+   simulation will run entirely in the visitor’s browser.
+
+## 📈 Future Work
+
+- Multi-agent learning with cooperative or competitive strategies
+- Deep Q-learning variations for richer state representations
+- Persistent storage for Q-tables across sessions via IndexedDB or cloud sync

--- a/index.html
+++ b/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mouse Escape Q-Learning Simulator</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>🐭 Mouse Escape: Q-Learning Agent</h1>
+    <p>
+      Train and visualize a Q-learning agent that helps a mouse escape the maze.
+      The simulation runs entirely in your browser and is ready for Netlify hosting.
+    </p>
+  </header>
+
+  <main>
+    <section class="controls">
+      <h2>Training Controls</h2>
+      <form id="training-form">
+        <label>
+          Episodes
+          <input type="number" id="episodes" min="1" value="2000" required />
+        </label>
+        <label>
+          Learning Rate (α)
+          <input type="number" id="alpha" min="0" max="1" step="0.01" value="0.2" required />
+        </label>
+        <label>
+          Discount Factor (γ)
+          <input type="number" id="gamma" min="0" max="1" step="0.01" value="0.95" required />
+        </label>
+        <label>
+          Epsilon Start
+          <input type="number" id="epsilon-start" min="0" max="1" step="0.01" value="1" required />
+        </label>
+        <label>
+          Epsilon End
+          <input type="number" id="epsilon-end" min="0" max="1" step="0.01" value="0.05" required />
+        </label>
+        <label>
+          Max Steps per Episode
+          <input type="number" id="max-steps" min="1" value="200" required />
+        </label>
+        <button type="submit" id="train-button">Train Agent</button>
+      </form>
+      <div class="status" id="status">Waiting to start training…</div>
+    </section>
+
+    <section class="visualization">
+      <h2>Environment</h2>
+      <div id="grid" class="grid" role="grid" aria-label="Maze grid"></div>
+      <div class="legend">
+        <span class="cell agent"></span> Agent Start (0, 0)
+        <span class="cell goal"></span> Goal (7, 7)
+        <span class="cell wall"></span> Wall
+        <span class="cell hell"></span> Hell State
+        <span class="cell teleporter"></span> Teleporter
+      </div>
+      <button id="play-button" disabled>Show Greedy Run</button>
+      <div class="status" id="run-status"></div>
+    </section>
+
+    <section class="metrics">
+      <h2>Training Metrics</h2>
+      <canvas id="reward-chart" width="640" height="320" aria-label="Training rewards chart"></canvas>
+      <div class="metrics-summary" id="metrics-summary"></div>
+    </section>
+  </main>
+
+  <footer>
+    <p>
+      Deploy on <a href="https://www.netlify.com/" target="_blank" rel="noopener">Netlify</a> as a static site.
+      No server-side code required.
+    </p>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js" integrity="sha384-OcmGeMNKFQjaFdVA0GuL2q79r5FhbF+6mBGo3k0gczIfC/KvDmEG+/+rHoMPAv7" crossorigin="anonymous"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  command = ""
+  publish = "."
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"

--- a/script.js
+++ b/script.js
@@ -1,0 +1,347 @@
+const GRID_SIZE = 8;
+const ACTIONS = [
+  { name: "up", delta: [0, -1] },
+  { name: "right", delta: [1, 0] },
+  { name: "down", delta: [0, 1] },
+  { name: "left", delta: [-1, 0] },
+];
+
+const environment = {
+  gridSize: GRID_SIZE,
+  walls: new Set([
+    "1,1",
+    "1,2",
+    "1,3",
+    "2,3",
+    "3,3",
+    "5,0",
+    "5,1",
+    "5,2",
+    "5,3",
+    "5,4",
+  ]),
+  hellStates: new Set(["3,5", "2,6", "4,6", "6,4"]),
+  teleporters: new Map([
+    ["0,5", { to: [4, 1] }],
+    ["6,2", { to: [2, 6] }],
+  ]),
+  start: [0, 0],
+  goal: [7, 7],
+  livingReward: -0.01,
+  goalReward: 10,
+  hellReward: -5,
+};
+
+const qTable = new Map();
+let trainingRewards = [];
+let rewardChart;
+
+function stateKey([x, y]) {
+  return `${x},${y}`;
+}
+
+function getQValues(state) {
+  const key = stateKey(state);
+  if (!qTable.has(key)) {
+    qTable.set(key, new Array(ACTIONS.length).fill(0));
+  }
+  return qTable.get(key);
+}
+
+function isInsideGrid([x, y]) {
+  return x >= 0 && y >= 0 && x < GRID_SIZE && y < GRID_SIZE;
+}
+
+function isWall([x, y]) {
+  return environment.walls.has(stateKey([x, y]));
+}
+
+function getNextState(state, actionIndex) {
+  const [dx, dy] = ACTIONS[actionIndex].delta;
+  const tentative = [state[0] + dx, state[1] + dy];
+
+  if (!isInsideGrid(tentative) || isWall(tentative)) {
+    return [...state];
+  }
+
+  const teleporter = environment.teleporters.get(stateKey(tentative));
+  if (teleporter) {
+    return [...teleporter.to];
+  }
+
+  return tentative;
+}
+
+function getReward(state) {
+  if (stateKey(state) === stateKey(environment.goal)) {
+    return environment.goalReward;
+  }
+  if (environment.hellStates.has(stateKey(state))) {
+    return environment.hellReward;
+  }
+  return environment.livingReward;
+}
+
+function isTerminal(state) {
+  return (
+    stateKey(state) === stateKey(environment.goal) ||
+    environment.hellStates.has(stateKey(state))
+  );
+}
+
+function greedyAction(state) {
+  const qValues = getQValues(state);
+  let maxIndex = 0;
+  let maxValue = qValues[0];
+  for (let i = 1; i < qValues.length; i += 1) {
+    if (qValues[i] > maxValue) {
+      maxValue = qValues[i];
+      maxIndex = i;
+    }
+  }
+  return maxIndex;
+}
+
+function epsilonGreedyAction(state, epsilon) {
+  if (Math.random() < epsilon) {
+    return Math.floor(Math.random() * ACTIONS.length);
+  }
+  return greedyAction(state);
+}
+
+async function trainAgent(options) {
+  const {
+    episodes,
+    alpha,
+    gamma,
+    epsilonStart,
+    epsilonEnd,
+    maxSteps,
+    statusNode,
+  } = options;
+
+  trainingRewards = [];
+  const epsilonDecay = Math.pow(epsilonEnd / epsilonStart || 0.0001, 1 / episodes);
+  let epsilon = epsilonStart;
+
+  for (let episode = 0; episode < episodes; episode += 1) {
+    let state = [...environment.start];
+    let totalReward = 0;
+
+    for (let step = 0; step < maxSteps; step += 1) {
+      const action = epsilonGreedyAction(state, epsilon);
+      const nextState = getNextState(state, action);
+      const reward = getReward(nextState);
+      const done = isTerminal(nextState);
+
+      const qValues = getQValues(state);
+      const nextQValues = getQValues(nextState);
+
+      qValues[action] =
+        qValues[action] +
+        alpha * (reward + gamma * Math.max(...nextQValues) - qValues[action]);
+
+      state = nextState;
+      totalReward += reward;
+
+      if (done) {
+        break;
+      }
+    }
+
+    trainingRewards.push(totalReward);
+    epsilon = Math.max(epsilon * epsilonDecay, epsilonEnd);
+
+    if (episode % Math.max(1, Math.floor(episodes / 20)) === 0) {
+      statusNode.textContent = `Episode ${episode + 1} / ${episodes} · ε=${epsilon
+        .toFixed(3)} · Latest reward: ${totalReward.toFixed(2)}`;
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+    }
+  }
+
+  statusNode.textContent = `Training complete! ε=${epsilon.toFixed(3)} · Last reward: ${
+    trainingRewards.at(-1)?.toFixed(2) ?? "0.00"
+  }`;
+}
+
+function drawGrid(agentPosition = environment.start) {
+  const grid = document.getElementById("grid");
+  grid.innerHTML = "";
+
+  for (let y = 0; y < GRID_SIZE; y += 1) {
+    for (let x = 0; x < GRID_SIZE; x += 1) {
+      const cell = document.createElement("div");
+      cell.className = "cell";
+      cell.setAttribute("role", "gridcell");
+      cell.setAttribute("aria-label", `Cell ${x},${y}`);
+
+      const key = stateKey([x, y]);
+      if (stateKey([x, y]) === stateKey(agentPosition)) {
+        cell.classList.add("agent", "active");
+        cell.innerHTML = "<span>🐭</span>";
+      } else if (stateKey([x, y]) === stateKey(environment.goal)) {
+        cell.classList.add("goal");
+        cell.innerHTML = "<span>🏁</span>";
+      } else if (environment.walls.has(key)) {
+        cell.classList.add("wall");
+        cell.innerHTML = "<span>🧱</span>";
+      } else if (environment.hellStates.has(key)) {
+        cell.classList.add("hell");
+        cell.innerHTML = "<span>🔥</span>";
+      } else if (environment.teleporters.has(key)) {
+        cell.classList.add("teleporter");
+        cell.innerHTML = "<span>🌀</span>";
+      }
+
+      grid.appendChild(cell);
+    }
+  }
+}
+
+function updateMetrics() {
+  if (!rewardChart) {
+    const ctx = document.getElementById("reward-chart").getContext("2d");
+    rewardChart = new Chart(ctx, {
+      type: "line",
+      data: {
+        labels: [],
+        datasets: [
+          {
+            label: "Episode Reward",
+            data: [],
+            borderColor: "#2563eb",
+            backgroundColor: "rgba(37, 99, 235, 0.2)",
+            borderWidth: 2,
+            pointRadius: 0,
+            tension: 0.25,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        scales: {
+          x: { title: { display: true, text: "Episode" } },
+          y: { title: { display: true, text: "Total Reward" } },
+        },
+      },
+    });
+  }
+
+  rewardChart.data.labels = trainingRewards.map((_, index) => index + 1);
+  rewardChart.data.datasets[0].data = trainingRewards;
+  rewardChart.update();
+
+  const metricsSummary = document.getElementById("metrics-summary");
+  if (trainingRewards.length === 0) {
+    metricsSummary.textContent = "Train the agent to populate metrics.";
+    return;
+  }
+
+  const lastHundred = trainingRewards.slice(-100);
+  const average =
+    trainingRewards.reduce((sum, value) => sum + value, 0) / trainingRewards.length;
+  const averageRecent =
+    lastHundred.reduce((sum, value) => sum + value, 0) / lastHundred.length;
+  const bestReward = Math.max(...trainingRewards).toFixed(2);
+
+  metricsSummary.innerHTML = `
+    <div>Episodes: <strong>${trainingRewards.length}</strong></div>
+    <div>Average Reward: <strong>${average.toFixed(2)}</strong></div>
+    <div>Average (Last 100): <strong>${averageRecent.toFixed(2)}</strong></div>
+    <div>Best Reward: <strong>${bestReward}</strong></div>
+  `;
+}
+
+async function playGreedyRun() {
+  const runStatus = document.getElementById("run-status");
+  runStatus.textContent = "Running greedy policy…";
+  let state = [...environment.start];
+  drawGrid(state);
+
+  const visited = new Set();
+
+  for (let step = 0; step < 200; step += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    const action = greedyAction(state);
+    const nextState = getNextState(state, action);
+    const reward = getReward(nextState);
+    drawGrid(nextState);
+
+    if (isTerminal(nextState)) {
+      runStatus.textContent =
+        reward === environment.goalReward
+          ? `Goal reached in ${step + 1} steps!`
+          : `Terminated in hell state after ${step + 1} steps.`;
+      return;
+    }
+
+    const key = stateKey(nextState);
+    if (visited.has(key)) {
+      runStatus.textContent =
+        "Agent entered a loop. Continue training to improve the policy.";
+      return;
+    }
+    visited.add(key);
+
+    state = nextState;
+  }
+
+  runStatus.textContent =
+    "Max steps reached without finding the goal. Consider additional training.";
+}
+
+function resetEnvironment() {
+  drawGrid(environment.start);
+  document.getElementById("run-status").textContent = "";
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const statusNode = document.getElementById("status");
+  const playButton = document.getElementById("play-button");
+  const trainButton = document.getElementById("train-button");
+
+  drawGrid(environment.start);
+  updateMetrics();
+
+  document
+    .getElementById("training-form")
+    .addEventListener("submit", async (event) => {
+      event.preventDefault();
+      playButton.disabled = true;
+      trainButton.disabled = true;
+      statusNode.textContent = "Training in progress…";
+      document.getElementById("run-status").textContent = "";
+
+      const episodes = Number(document.getElementById("episodes").value);
+      const alpha = Number(document.getElementById("alpha").value);
+      const gamma = Number(document.getElementById("gamma").value);
+      const epsilonStart = Number(
+        document.getElementById("epsilon-start").value
+      );
+      const epsilonEnd = Number(document.getElementById("epsilon-end").value);
+      const maxSteps = Number(document.getElementById("max-steps").value);
+
+      await trainAgent({
+        episodes,
+        alpha,
+        gamma,
+        epsilonStart,
+        epsilonEnd,
+        maxSteps,
+        statusNode,
+      });
+
+      updateMetrics();
+      resetEnvironment();
+      playButton.disabled = false;
+      trainButton.disabled = false;
+    });
+
+  playButton.addEventListener("click", () => {
+    playButton.disabled = true;
+    playGreedyRun().finally(() => {
+      playButton.disabled = false;
+    });
+  });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,176 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  background-color: #f5f7fb;
+  color: #20222a;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, #f9fbff 0%, #eef2ff 100%);
+}
+
+header,
+footer {
+  padding: 1.5rem 2rem;
+  background-color: rgba(33, 56, 117, 0.1);
+  backdrop-filter: blur(6px);
+}
+
+header h1 {
+  margin: 0 0 0.5rem 0;
+  font-size: 2rem;
+}
+
+main {
+  flex: 1;
+  display: grid;
+  gap: 1.5rem;
+  padding: 1.5rem 2rem 3rem 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+section {
+  background-color: rgba(255, 255, 255, 0.75);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 12px 40px rgba(20, 32, 80, 0.12);
+}
+
+.controls form {
+  display: grid;
+  gap: 1rem;
+}
+
+.controls label {
+  display: flex;
+  flex-direction: column;
+  font-weight: 600;
+  gap: 0.3rem;
+}
+
+.controls input {
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.65rem;
+  border: 1px solid rgba(33, 56, 117, 0.2);
+  font-size: 0.95rem;
+}
+
+button {
+  padding: 0.75rem 1.2rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #1d4ed8, #3b82f6);
+  color: white;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:disabled {
+  background: linear-gradient(135deg, #94a3b8, #cbd5f5);
+  cursor: not-allowed;
+}
+
+button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(37, 99, 235, 0.25);
+}
+
+.status {
+  margin-top: 1rem;
+  font-weight: 500;
+  min-height: 1.5rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  grid-template-rows: repeat(8, 1fr);
+  gap: 0.4rem;
+  width: min(100%, 420px);
+  aspect-ratio: 1 / 1;
+  margin-bottom: 1.5rem;
+}
+
+.cell {
+  border-radius: 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: #0f172a;
+  background-color: rgba(148, 163, 184, 0.2);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cell span {
+  pointer-events: none;
+}
+
+.cell.active {
+  transform: scale(1.05);
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.35);
+}
+
+.cell.wall {
+  background: repeating-linear-gradient(135deg, #1e293b, #1e293b 8px, #475569 8px, #475569 16px);
+  color: white;
+}
+
+.cell.hell {
+  background: radial-gradient(circle at top left, #f87171, #b91c1c);
+  color: white;
+}
+
+.cell.goal {
+  background: radial-gradient(circle at center, #34d399, #0f766e);
+  color: white;
+}
+
+.cell.teleporter {
+  background: radial-gradient(circle at center, #facc15, #d97706);
+  color: #1f2937;
+}
+
+.cell.agent {
+  background: radial-gradient(circle at center, #3b82f6, #1d4ed8);
+  color: white;
+}
+
+.legend {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.legend .cell {
+  width: 1.5rem;
+  height: 1.5rem;
+  font-size: 0;
+  box-shadow: none;
+}
+
+.metrics-summary {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.75rem;
+  font-weight: 500;
+}
+
+@media (max-width: 768px) {
+  main {
+    grid-template-columns: 1fr;
+    padding: 1.5rem;
+  }
+
+  header,
+  footer {
+    padding: 1.25rem 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the README with instructions for the new browser-based simulator and Netlify deployment guidance
- add a fully client-side Q-learning simulation with interactive controls, metrics, and visualization
- include styling, Chart.js integration, and a minimal Netlify publish configuration

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e0fb7f28848321bcdd2f41c4cdffef